### PR TITLE
Fix font size's in dialog being incorrect (#19)

### DIFF
--- a/HeartRate/Prompt.cs
+++ b/HeartRate/Prompt.cs
@@ -18,22 +18,23 @@ namespace HeartRate
 
             color = dlg.Color;
             return true;
-
         }
 
         public static bool TryFont(
-            string currentFond,
+            string currentFont,
             FontStyle currentStyle,
             int currentSize,
             out Font font)
         {
             font = default;
 
-            using var dlgFont = new Font(currentFond, currentSize, currentStyle, GraphicsUnit.Pixel);
+            // Even though it's not really in "points," this prevents it from converting our PX size to Points, and
+            // any conversion roundings that would happen.
+            using var dlgFont = new Font(currentFont, currentSize, currentStyle, GraphicsUnit.Point);
             using var dlg = new FontDialog
             {
                 FontMustExist = true,
-                Font = dlgFont,
+                Font = dlgFont
             };
 
             if (dlg.ShowDialog() != DialogResult.OK) return false;
@@ -57,7 +58,6 @@ namespace HeartRate
 
             file = dlg.FileName;
             return true;
-
         }
     }
 }

--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,9 @@ by request.**
 
 Change log
 ----------
+**1.7.1** December 29th, 2020
+* Fixed font size in dialog not being what was entered. (#19)
+
 **1.7** November 30th, 2020
 * Added text alignment option. (#17)
 * Added window size being saved. (#17)


### PR DESCRIPTION
When creating the font, it was converting the pixel units into point units, causing an offset.