### PR TITLE
Added another compatible device

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,6 +9,7 @@ This has only been tested on a [Polar H7](https://www.amazon.com/dp/B007S088F4) 
 Reportedly working devices include:
 * Polar H7, Polar OH1, Polar 10
 * Coospo HRM
+* Magene H64
 
 Requires Windows 8.1 or newer.
 


### PR DESCRIPTION
Not sure if you're still adding to this list, but one of the cheaper chest heart rate trackers on Amazon, the [Magene H64](https://www.amazon.com/dp/B0B1CV2S6V) ($20, non-referral link) works with this software. If you're not still adding or aren't listing devices like this, no worries, feel free to close the PR